### PR TITLE
Set DB backup retention period to 3 days for production

### DIFF
--- a/playbooks/artemis-production/production-db.yml
+++ b/playbooks/artemis-production/production-db.yml
@@ -14,6 +14,7 @@
       vars:
         artemis_database_backup_dir: /srv/artemis-db
         artemis_database_backup_script_path: /opt/artemis-backup.sh
+        artemis_database_backup_retention: 3
 
     - role: ls1intum.artemis.firewall
       tags: firewall


### PR DESCRIPTION
### Motivation and Context

The production VM is slowly running out of disk space. As the VM is also backed up by the RBG, we do not need a long history of DB backups.


### Description

Set a custom retention period of 3 days.

https://github.com/ls1intum/artemis-ansible-collection/pull/131


### Steps for Deployment

Check whether the storage space of the prod DB VM is reduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented an updated backup retention policy ensuring database backups are maintained for three cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->