### PR TITLE
Enable passkeys for Staging 1, Staging LocalCI, and Test Servers

### DIFF
--- a/group_vars/artemis_staging1.yml
+++ b/group_vars/artemis_staging1.yml
@@ -12,6 +12,8 @@ artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/stagi
 artemis_internal_admin_user: artemis_admin
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/staging1').get('internal_admin') }}"
 
+artemis_passkey_enabled: true
+
 artemis_repo_basepath: "/mnt/storage"
 artemis_legal_path: "/mnt/storage/legal"
 artemis_data_export_path: "/mnt/storage/data-exports"

--- a/group_vars/artemis_staging_localci.yml
+++ b/group_vars/artemis_staging_localci.yml
@@ -9,6 +9,8 @@ var_artemis_localvc_ssh_url: "ssh://git@artemis-staging-integrated-code-lifecycl
 
 registry_external_host: artemis-staging-localci-registry.artemis.cit.tum.de
 
+artemis_passkey_enabled: true
+
 ##############################################################################
 # External Systems Configuration
 ##############################################################################

--- a/group_vars/artemistests_common_config.yml
+++ b/group_vars/artemistests_common_config.yml
@@ -11,6 +11,7 @@ artemis_version: develop
 artemis_branch: develop
 
 artemis_internal_admin_user: artemis_admin
+artemis_passkey_enabled: true
 artemis_repo_basepath: "/opt/artemis/data"
 
 push_notification_relay: "https://hermes-sandbox.artemis.cit.tum.de"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure that all continuous integration checks are passing. -->

### Motivation and Context

https://github.com/ls1intum/Artemis/pull/10656
https://github.com/ls1intum/artemis-ansible-collection/pull/130


### Description

Enable passkey support for Staging LocalCI, Staging 1, and Test Servers.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration toggle that enables passkey functionality across multiple environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->