### PR TITLE
Change default server

### DIFF
--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -41,13 +41,17 @@ servers:
   - name: "artemis.tum.de"
     ssl_certificate_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_name }}"
     ssl_certificate_key_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_key_name }}"
+    default_server: true
+  - name: "artemis.ase.cs.tum.edu "
+    ssl_certificate_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.fullchain.pem
+    ssl_certificate_key_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.privkey.pem
     default_server: false
 
 redirects:
-  - name: "_"
+  - name: "artemis.ase.in.tum.de artemis.in.tum.de artemis.ase.cit.tum.de proxy.prod.artemis.cit.tum.de artemis.cs.tum.edu proxy-internal.prod.artemis.cit.tum.de prod.artemis.cit.tum.de asevm91.cit.tum.de artemis.cit.tum.de"
     ssl_certificate_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.fullchain.pem
     ssl_certificate_key_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.privkey.pem
-    default_server: true
+    default_server: false
     to: "{{ artemis_server_url }}"
 
 firewall_hostgroup: default

--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -42,7 +42,7 @@ servers:
     ssl_certificate_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_name }}"
     ssl_certificate_key_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_key_name }}"
     default_server: true
-  - name: "artemis.ase.cs.tum.edu "
+  - name: "artemis.ase.cs.tum.edu"
     ssl_certificate_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.fullchain.pem
     ssl_certificate_key_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.privkey.pem
     default_server: false

--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -42,10 +42,6 @@ servers:
     ssl_certificate_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_name }}"
     ssl_certificate_key_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_key_name }}"
     default_server: true
-  - name: "artemis.ase.cs.tum.edu"
-    ssl_certificate_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.fullchain.pem
-    ssl_certificate_key_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.privkey.pem
-    default_server: false
 
 redirects:
   - name: "artemis.ase.in.tum.de artemis.in.tum.de artemis.ase.cit.tum.de proxy.prod.artemis.cit.tum.de artemis.cs.tum.edu proxy-internal.prod.artemis.cit.tum.de prod.artemis.cit.tum.de asevm91.cit.tum.de artemis.cit.tum.de"


### PR DESCRIPTION
### Description

- Set `artemis.tum.de` as the default server so that requests without Server Name Indication work for the main URL (instead of the legacy URLs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated server and redirect configurations for improved hostname handling and SSL certificate specification.
  - Adjusted default server assignments for better traffic management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->