### PR TITLE
`Development`: Set bamboo as deployment_user_name

### DIFF
--- a/group_vars/artemis_staging_localci.yml
+++ b/group_vars/artemis_staging_localci.yml
@@ -43,3 +43,5 @@ redirects:
 
 firewall_hostgroup: default
 proxy_forward_ssh: true
+
+artemis_deployment_user_name: bamboo


### PR DESCRIPTION
### Motivation and Context
In the prod like config the deployment_user_name is hardcoded to deployment. Staging LocalCI was created previously and still has bamboo as deployment_user_name.


### Description
Set deployment_user_name to bamboo.

The user can be renamed in the future.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to include a new deployment user setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->