### PR TITLE
`Development`: Move mail config to prod-like config

### DIFF
--- a/group_vars/artemis_prod_like_common.yml
+++ b/group_vars/artemis_prod_like_common.yml
@@ -34,6 +34,14 @@ ldap:
   base: "{{ lookup('hashi_vault', 'kv/data/artemis/common/ldap').get('ldap_base') }}"
   password: "{{ lookup('hashi_vault', 'kv/data/artemis/common/ldap').get('ldap_password') }}"
 
+mail:
+  hostname: "{{ lookup('hashi_vault', 'kv/data/artemis/common/mail').get('mail_host') }}"
+  port: "587"
+  username: "{{ lookup('hashi_vault', 'kv/data/artemis/common/mail').get('mail_user') }}"
+  password: "{{ lookup('hashi_vault', 'kv/data/artemis/common/mail').get('mail_password') }}"
+  protocol: "smtp"
+  ssl_trust: "postout.lrz.de"
+
 version_control:
   localvc:
     url: "{{ artemis_server_url }}"

--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -13,14 +13,6 @@ registry_external_host: registry.prod.artemis.cit.tum.de
 # External Systems Configuration
 ##############################################################################
 
-mail:
-  hostname: "{{ lookup('hashi_vault', 'kv/data/artemis/common/mail').get('mail_host') }}"
-  port: "587"
-  username: "{{ lookup('hashi_vault', 'kv/data/artemis/common/mail').get('mail_user') }}"
-  password: "{{ lookup('hashi_vault', 'kv/data/artemis/common/mail').get('mail_password') }}"
-  protocol: "smtp"
-  ssl_trust: "postout.lrz.de"
-
 athena:
   url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('url') }}"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('secret') }}"


### PR DESCRIPTION
### Motivation and Context

The mail service was not active for the staging environments even though they should be.

### Description

We moved the common mail config from the production configuration to the prod-like configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to centralize mail server settings, consolidating credentials and connection details into a common location for improved management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->