### PR TITLE
`Development`: Add helios config for testservers

### DIFF
--- a/group_vars/artemistests_common_config.yml
+++ b/group_vars/artemistests_common_config.yml
@@ -35,6 +35,14 @@ lti:
 licenses:
   matlab: "28000@mlm1.rbg.tum.de"
 
+helios:
+  environment_name: "{{ var_testserver_name }}.artemis.cit.tum.de"
+  endpoints:
+    - url: "https://helios.aet.cit.tum.de/api/environments/status"
+      secret_key: "{{ lookup('hashi_vault', 'kv/data/artemis/common/helios').get('prod_secret_key') }}"
+    - url: "https://helios-staging.aet.cit.tum.de/api/environments/status"
+      secret_key: "{{ lookup('hashi_vault', 'kv/data/artemis/common/helios').get('staging_secret_key') }}"
+
 ##############################################################################
 # Proxy Configuration
 ##############################################################################


### PR DESCRIPTION
### Motivation and Context
https://github.com/ls1intum/artemis-ansible-collection/pull/146



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration section for Helios, including dynamic environment naming and a list of API endpoints for production and staging, each with securely retrieved secret keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->