### PR TITLE
`Development`: Remove legacy var_vm_name for test servers

### DIFF
--- a/group_vars/artemistest1.yml
+++ b/group_vars/artemistest1.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test1"
-var_vm_name: "vmbhatotia172"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest1').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest1').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest1').get('jhipster_jwt') }}"

--- a/group_vars/artemistest10.yml
+++ b/group_vars/artemistest10.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test10"
-var_vm_name: "vmbhatotia181"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest10').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest10').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest10').get('jhipster_jwt') }}"

--- a/group_vars/artemistest2.yml
+++ b/group_vars/artemistest2.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test2"
-var_vm_name: "vmbhatotia175"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest2').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest2').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest2').get('jhipster_jwt') }}"

--- a/group_vars/artemistest3.yml
+++ b/group_vars/artemistest3.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test3"
-var_vm_name: "vmbhatotia173"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest3').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest3').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest3').get('jhipster_jwt') }}"

--- a/group_vars/artemistest4.yml
+++ b/group_vars/artemistest4.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test4"
-var_vm_name: "vmbhatotia176"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest4').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest4').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest4').get('jhipster_jwt') }}"

--- a/group_vars/artemistest5.yml
+++ b/group_vars/artemistest5.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test5"
-var_vm_name: "vmbhatotia174"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest5').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest5').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest5').get('jhipster_jwt') }}"

--- a/group_vars/artemistest6.yml
+++ b/group_vars/artemistest6.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test6"
-var_vm_name: "vmbhatotia177"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest6').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest6').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest6').get('jhipster_jwt') }}"

--- a/group_vars/artemistest7.yml
+++ b/group_vars/artemistest7.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test7"
-var_vm_name: "vmbhatotia177"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest7').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest7').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest7').get('jhipster_jwt') }}"

--- a/group_vars/artemistest9.yml
+++ b/group_vars/artemistest9.yml
@@ -3,7 +3,6 @@
 # Commonly changed variables
 ##############################################################################
 var_testserver_name: "artemis-test9"
-var_vm_name: "vmbhatotia180"
 artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest9').get('db_password') }}"
 artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest9').get('internal_admin') }}"
 artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest9').get('jhipster_jwt') }}"

--- a/group_vars/artemistestX-template.yml
+++ b/group_vars/artemistestX-template.yml
@@ -4,6 +4,5 @@
 ##############################################################################
 is_testserver: true
 var_testserver_name: "artemis-testX"
-var_vm_name: "vmbhatotiaX"
 artemis_database_password: "TODO"
 artemis_internal_admin_password: "TODO"


### PR DESCRIPTION

### Motivation and Context

`var_vm_name` is unused and still contains old values.

### Description

Remove `var_vm_name`.
