### PR TITLE
`Development`: Migrate theia config to common group vars

### DIFF
--- a/group_vars/artemistest1.yml
+++ b/group_vars/artemistest1.yml
@@ -23,19 +23,3 @@ athena:
   url: "https://athena-test1.ase.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest1').get('athena_secret') }}"
   restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"
-
-theia:
-  portal_url: https://theia-staging.artemis.cit.tum.de
-  images:
-    java:
-      Java-17: "java-17-latest"
-    c:
-      C: "c-latest"
-    javascript:
-      Javascript: "javascript-latest"
-    ocaml:
-      Ocaml: "ocaml-latest"
-    python:
-      Python: "python-latest"
-    rust:
-      Rust: "rust-latest"

--- a/group_vars/artemistest2.yml
+++ b/group_vars/artemistest2.yml
@@ -11,19 +11,3 @@ athena:
   url: "https://athena-test1.ase.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest2').get('athena_secret') }}"
   restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"
-
-theia:
-  portal_url: https://theia-staging.artemis.cit.tum.de
-  images:
-    java:
-      Java-17: "java-17-latest"
-    c:
-      C: "c-latest"
-    javascript:
-      Javascript: "javascript-latest"
-    ocaml:
-      Ocaml: "ocaml-latest"
-    python:
-      Python: "python-latest"
-    rust:
-      Rust: "rust-latest"

--- a/group_vars/artemistest3.yml
+++ b/group_vars/artemistest3.yml
@@ -23,19 +23,3 @@ athena:
   url: "https://athena-test1.ase.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest3').get('athena_secret') }}"
   restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"
-
-theia:
-  portal_url: https://theia-staging.artemis.cit.tum.de
-  images:
-    java:
-      Java-17: "java-17-latest"
-    c:
-      C: "c-latest"
-    javascript:
-      Javascript: "javascript-latest"
-    ocaml:
-      Ocaml: "ocaml-latest"
-    python:
-      Python: "python-latest"
-    rust:
-      Rust: "rust-latest"

--- a/hosts
+++ b/hosts
@@ -121,6 +121,9 @@ artemistest9
 artemistest10
 
 [artemistests_theia:children]
+artemistest1
+artemistest2
+artemistest3
 artemistest9
 
 [artemis_infrastructure]


### PR DESCRIPTION
### Motivation and Context
Follow-up to #56 

Previously we had different Theia URLs for each test server. Therefore, it was not possible to have a common configuration.

In #56, the Theia Portal URL was changed so that all test servers have the same configuration. This allows us to remove config duplication.

### Description
Remove duplicate config values and add test server 1 to 3 to the theia group.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Theia portal configuration from test environments
  * Added three new test host entries to the infrastructure group

<!-- end of auto-generated comment: release notes by coderabbit.ai -->