### PR TITLE
`Development`: Fix Ansible deprecation warnings

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -83,12 +83,6 @@ hash_behaviour = merge
 # if passing --private-key to ansible or ansible-playbook
 #private_key_file = /path/to/file
 
-# format of string {{ ansible_managed }} available within Jinja2
-# templates indicates to users editing templates files will be replaced.
-# replacing {file}, {host} and {uid} and strftime codes with proper values.
-#ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
-ansible_managed = Ansible managed: Do not make changes here - they will be overwritten.
-
 # by default, ansible-playbook will display "Skipping [host]" if it determines a task
 # should not be run on a host.  Set this to "False" if you don't want to see these "Skipping"
 # messages. NOTE: the task header will still be shown regardless of whether or not the

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,6 @@
 ---
+ansible_managed: "Ansible managed: Do not make changes here - they will be overwritten."
+
 no_proxy: "localhost,127.0.0.1/8,::1,131.159.0.0/16,2a09:80c0::/29,172.16.0.0/12,10.0.0.0/8,*.in.tum.de,*cit.tum.de"
 
 shared_monitoring_host_v4: "131.159.89.160"


### PR DESCRIPTION

### Motivation and Context
https://github.com/ls1intum/artemis-ansible-collection/pull/188


### Description
Migrate `ansible_managed` to normal variable defined globally for all groups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized configuration management settings across infrastructure configuration files for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->