### PR TITLE
`Development`: Add playbooks for artemis-test-migration

### DIFF
--- a/host_vars/artemis-test-migration.artemis.cit.tum.de.yml
+++ b/host_vars/artemis-test-migration.artemis.cit.tum.de.yml
@@ -1,0 +1,14 @@
+---
+##############################################################################
+# Commonly changed variables
+##############################################################################
+var_testserver_name: "artemis-test-migration"
+artemis_database_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistestmigration').get('db_password') }}"
+artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistestmigration').get('internal_admin') }}"
+artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistestmigration').get('jhipster_jwt') }}"
+
+artemis_database_temp_container_name: artemis-temp-db
+artemis_database_container_name: artemis-db
+
+mysql_base: mysql:8.0.45
+mysql_baked: artemis_db

--- a/hosts
+++ b/hosts
@@ -31,6 +31,9 @@ artemis-test-vm9.artemis.cit.tum.de
 [artemistest10]
 artemis-test10.artemis.cit.tum.de
 
+[artemistestmigration]
+artemis-test-migration.artemis.cit.tum.de
+
 [artemistests:children]
 artemistest1
 artemistest2
@@ -52,6 +55,7 @@ artemistest7
 artemistest8
 artemistest9
 artemistest10
+artemistestmigration
 
 [artemistests_mysql:children]
 artemistest1
@@ -59,6 +63,7 @@ artemistest2
 artemistest5
 artemistest7
 artemistest9
+artemistestmigration
 
 [artemistests_postgres:children]
 artemistest3
@@ -73,6 +78,7 @@ artemistest3
 artemistest4
 artemistest7
 artemistest9
+artemistestmigration
 
 [artemistests_local_vc_jenkins:children]
 artemistest5
@@ -95,6 +101,7 @@ artemistest6
 artemistest8
 artemistest9
 artemistest10
+artemistestmigration
 
 [artemistests_atlas:children]
 artemistest1

--- a/playbooks/artemis-migration/migration_load_new_db_backup.yml
+++ b/playbooks/artemis-migration/migration_load_new_db_backup.yml
@@ -1,0 +1,10 @@
+---
+- name: Migration tester
+  hosts: artemis-test-migration.artemis.cit.tum.de
+
+  roles:
+    - role: ls1intum.artemis.migration_tester
+      become: true
+      vars:
+        dump_src: "~/artemis_backup.sql.gz"
+        bake: true

--- a/playbooks/artemis-migration/migration_reset_db.yml
+++ b/playbooks/artemis-migration/migration_reset_db.yml
@@ -1,0 +1,7 @@
+---
+- name: Migration tester
+  hosts: artemis-test-migration.artemis.cit.tum.de
+
+  roles:
+    - role: ls1intum.artemis.migration_tester
+      become: true

--- a/playbooks/artemis-migration/migration_setup.yml
+++ b/playbooks/artemis-migration/migration_setup.yml
@@ -1,0 +1,12 @@
+---
+- name: Migration tester
+  hosts: artemis-test-migration.artemis.cit.tum.de
+
+  roles:
+    - role: ls1intum.artemis.artemis
+      tags: artemis
+      vars:
+        setup_system: true
+
+    - role: ls1intum.artemis.legal
+      tags: legal


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure that all continuous integration checks are passing. -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If there are related PRs in the Artemis or artemis-ansible-collection repositories, please link them here. -->
This are the files to use artemis-test-migration; for more, see https://github.com/ls1intum/artemis-ansible-collection/pull/190

### Description
<!-- Describe your changes in detail -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated test migration host and automated playbooks to load DB backups, reset databases, and perform initial migration setup.

* **Chores**
  * Added a new inventory group and host entry.
  * Centralized host variables: test server name, DB/container names, MySQL base image, JHipster JWT and admin credentials sourced from Vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->