### PR TITLE
`Development`: Use new openai azure keys

### DIFF
--- a/group_vars/artemis_prod_like_common.yml
+++ b/group_vars/artemis_prod_like_common.yml
@@ -76,7 +76,7 @@ artemis_hyperion_enabled: true
 
 spring_ai:
   azure_openai:
-    api_key: "{{ lookup('hashi_vault', 'kv/data/artemis/common/hyperion').get('azure_openai_api_key') }}"
+    api_key: "{{ lookup('hashi_vault', 'kv/data/artemis/common/hyperion').get('azure_openai_api_key_prod') }}"
     endpoint: "{{ lookup('hashi_vault', 'kv/data/artemis/common/hyperion').get('azure_openai_endpoint') }}"
     deployment_name: "{{ lookup('hashi_vault', 'kv/data/artemis/common/hyperion').get('azure_openai_deployment_name') }}"
     temperature: 1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the Azure OpenAI credential reference to the production key in configuration to strengthen secret handling and key management practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->