### PR TITLE
Enable Athena on Production again

### DIFF
--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -13,6 +13,11 @@ registry_external_host: registry.prod.artemis.cit.tum.de
 # External Systems Configuration
 ##############################################################################
 
+athena:
+  url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('url') }}"
+  secret: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('secret') }}"
+  restricted_modules: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('restricted_modules') }}"
+
 nebula:
   url: "https://prod.nebula.artemis.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/common/nebula').get('prod_secret') }}"


### PR DESCRIPTION


<!-- Thanks for contributing! Before you submit your pull request, please make sure that all continuous integration checks are passing. -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If there are related PRs in the Artemis or artemis-ansible-collection repositories, please link them here. -->
Athena is now ready to be enabled on Artemis production again.

### Description
<!-- Describe your changes in detail -->
This reverts commit 01ce8e408646750b189a87fbe0696c80b20c88dc, which disabled Athena previously.
Also, the URL and the `athena-secret` changed and need to be updated in the vault.

### Steps for Deployment
<!-- Please describe how to deploy the changes (e.g. the names of the playbooks). -->
<!-- Please add the corresponding labels `needs deployment: test`, `needs deployment: dev cluster`, `needs deployment: staging`, `needs deployment: prod` or `is deployed: test`, `is deployed: dev cluster`, `is deployed: staging`, or `is deployed: prod`. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added production configuration support for athena external system integration, including URL, secret, and restricted module settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/artemis-ansible/pull/73)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->