### PR TITLE
Update Athena Test URL to new VM on Artemis Testservers

### DIFF
--- a/group_vars/artemistest1.yml
+++ b/group_vars/artemistest1.yml
@@ -22,6 +22,6 @@ artemis_eureka_urls: "http://{{ artemis_jhipster_registry_usernamme }}:{{ artemi
 weaviate_collection_prefix: "Artemis_ts1_"
 
 athena:
-  url: "https://athena-test1.ase.cit.tum.de"
+  url: "https://athena-test1.aet.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest1').get('athena_secret') }}"
   restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"

--- a/group_vars/artemistest2.yml
+++ b/group_vars/artemistest2.yml
@@ -10,7 +10,7 @@ artemis_jhipster_jwt: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistes
 weaviate_collection_prefix: "Artemis_ts2_"
 
 athena:
-  url: "https://athena-test1.ase.cit.tum.de"
+  url: "https://athena-test1.aet.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest2').get('athena_secret') }}"
   restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"
 

--- a/group_vars/artemistest3.yml
+++ b/group_vars/artemistest3.yml
@@ -22,7 +22,7 @@ artemis_eureka_urls: "http://{{ artemis_jhipster_registry_usernamme }}:{{ artemi
 weaviate_collection_prefix: "Artemis_ts3_"
 
 athena:
-  url: "https://athena-test1.ase.cit.tum.de"
+  url: "https://athena-test1.aet.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest3').get('athena_secret') }}"
   restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"
 


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure that all continuous integration checks are passing. -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If there are related PRs in the Artemis or artemis-ansible-collection repositories, please link them here. -->
We moved Athena to a new test environment. Artemis Test 1-3 should now connect to the new Athena Test VM via the updated URL.

### Description
<!-- Describe your changes in detail -->
Updates the URL for Athena in Artemis TS1-TS3 group_vars to the new URL.


### Steps for Deployment
<!-- Please describe how to deploy the changes (e.g. the names of the playbooks). -->
<!-- Please add the corresponding labels `needs deployment: test`, `needs deployment: dev cluster`, `needs deployment: staging`, `needs deployment: prod` or `is deployed: test`, `is deployed: dev cluster`, `is deployed: staging`, or `is deployed: prod`. -->
