### PR TITLE
Document 2-segment Artemis release tags and YAML quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ ansible-playbook playbooks/<server>/nodes-version-update.yml -e artemis_version=
 ansible-playbook playbooks/artemis-production/production-nodes-version-update.yml -e artemis_version=<version> # For production
 ```
 
-The `<version>` variable can be set to a specific [GitHub release version](https://github.com/ls1intum/Artemis/releases) (e.g., `8.0.0`) or to an absolute path to a local Artemis executable (e.g., `/home/user/Artemis.war`).
+The `<version>` variable can be set to a specific [GitHub release tag](https://github.com/ls1intum/Artemis/releases) — either 3-segment (`9.1.2`) or 2-segment (`9.2`) — or to an absolute path to a local Artemis executable (e.g., `/home/user/Artemis.war`).
+
+> **YAML quoting (important for 2-segment tags):** when recording a 2-segment version inside a `group_vars` or `host_vars` file, always quote it: `artemis_version: "9.2"`. Without quotes YAML parses `9.2` as a float and `9.10` silently becomes `9.1`. Passing `-e artemis_version=9.2` on the command line (`key=value` form) is string-safe, but inline JSON/YAML-form extra-vars (`-e '{"artemis_version": 9.2}'`) still need explicit quoting.
 
 ### Updating Artemis Configuration on a Host
 


### PR DESCRIPTION
## Summary

- Update the "Deploying New Artemis Version" section to mention both 2-segment (`9.2`) and 3-segment (`9.1.2`) [GitHub release tags](https://github.com/ls1intum/Artemis/releases).
- Warn about the YAML float footgun: unquoted `9.2` parses as a float; `9.10` silently becomes `9.1`. `-e key=value` form on the CLI is safe; inline JSON/YAML extra-vars and group_vars/host_vars values must be quoted.

## Why

Artemis 9.2+ uses 2-segment release tags. This change documents the operator-facing requirement so 2-segment tags can be used safely from `group_vars` / `host_vars`.

## Companion PR

Depends on https://github.com/ls1intum/artemis-ansible-collection/pull/203 for the regex fix and the role-entry string-assert. After both PRs merge, refresh the local collection with `ansible-galaxy collection install -r requirements.yml --force` before deploying `9.2`.

## Test plan

- [ ] Render the new README section visually (Markdown blockquote).
- [ ] After merging the companion PR and refreshing the collection, deploy `9.2` to `staging2`: `ansible-playbook playbooks/artemis-staging2/nodes-version-update.yml -e artemis_version=9.2` succeeds.
- [ ] Set `artemis_version: 9.2` (unquoted) in a test `group_vars` file and confirm the new assert fires with the documented error.