### PR TITLE
Re-enable Sentry on prod

### DIFF
--- a/group_vars/artemis_prod_like_common.yml
+++ b/group_vars/artemis_prod_like_common.yml
@@ -106,6 +106,13 @@ artemis_jhipster_registry_password: "{{ lookup('hashi_vault', 'kv/data/artemis/'
 artemis_eureka_instance_id: "{{ node_id }}"
 
 ##############################################################################
+# Sentry Common Configuration
+##############################################################################
+sentry:
+  dsn: https://e52d0b9b6b61769f50b088634b4bc781@sentry.aet.cit.tum.de/2
+  send_default_pii: true
+
+##############################################################################
 # Deployment User
 ##############################################################################
 

--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -62,6 +62,13 @@ redirects:
 firewall_hostgroup: default
 proxy_forward_ssh: true
 
+##############################################################################
+# Sentry Env-specific Configuration
+##############################################################################
+sentry:
+  environment: prod
+  traces_sample_rate: 0.2
+
 theia:
   portal_url: https://theia.artemis.cit.tum.de
   images:


### PR DESCRIPTION
## Summary

Restores the Sentry config for prod that commit `bee5258` deleted (direct push to main, 2026-02-19, no PR). Brings `main` back in line with prod's deployed state.

## Background

- Today's `production-nodes-update-config.yml` rollout aligned `/opt/artemis/application-prod.yml` with merged `main`. The Sentry block rendered as `sentry:\n  dsn:` because `bee5258` had removed the variables.
- The client SDK (already initialized with Sentry support) began 504-ing on envelope requests
- Git history shows no PR to re-enable Sentry on prod between Feb 19 and today. Conclusion: someone's local clone had silently been keeping the vars set and applying via ansible without committing, so prod's deployed state diverged from `main` for 3 months.

## Change

Two-file revert of the prod-Sentry portion of `bee5258`:

- `group_vars/artemis_prod_like_common.yml`: restore the common `sentry: { dsn, send_default_pii: true }` block.
- `group_vars/artemis_production.yml`: restore the env-specific `sentry: { environment: prod, traces_sample_rate: 0.2 }` block.

With `hash_behaviour = merge` (in `ansible.cfg`), these combine at render time into the same dict that existed pre-`bee5258`.

## Side effect to flag

`staging_localci` does not have its own `sentry.dsn`/`send_default_pii` override (unlike `staging1`/`staging2`), so this PR implicitly re-enables Sentry there too. That matches the pre-`bee5258` state. If `staging_localci` should stay sentry-off, add a per-env override later.

## Verification

Already applied live before this PR (operational urgency from Slack thread):

- Dry-run produced byte-for-byte sign-flipped inverse of the deploy that broke Sentry: 224 sentry-related diff lines, zero discrepancies.
- Live `ansible-playbook playbooks/artemis-production/production-nodes-update-config.yml -e restart_artemis=true --diff` succeeded with `failed=0` on all 24 hosts (4 core + 20 agents). Node1 health gate passed in ~45s.
- `curl https://artemis.tum.de/management/info` now reports `info.sentry.dsn` populated on all 4 nodes. Version stayed at 9.2; `athena` profile still active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated error tracking and performance monitoring for production environments
  * Enabled personally identifiable information collection in error reports
  * Configured performance tracing at 20% sample rate

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/artemis-ansible/pull/76)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->