### PR TITLE
Remove orphan group_vars/artemistests_aeolus.yml

### DIFF
--- a/group_vars/artemistests_aeolus.yml
+++ b/group_vars/artemistests_aeolus.yml
@@ -1,7 +1,0 @@
----
-##############################################################################
-# Aeolus Configuration
-##############################################################################
-aeolus:
-  url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/aeolus').get('url') }}"
-  token: "{{ lookup('hashi_vault', 'kv/data/artemis/common/aeolus').get('token') }}"


### PR DESCRIPTION
## Summary

Delete `group_vars/artemistests_aeolus.yml`. Aeolus was removed from Artemis in [ls1intum/Artemis#12536](https://github.com/ls1intum/Artemis/pull/12536), and the corresponding template / env-var / Spring-profile config in `ls1intum.artemis` is being removed in [ls1intum/artemis-ansible-collection#208](https://github.com/ls1intum/artemis-ansible-collection/pull/208). After that lands, this file has no consumer left in the collection either.

## Verification

The file is already orphan in this repo:

```
$ grep -rn "artemistests_aeolus\|aeolus" hosts host_vars playbooks
(no matches)
```

i.e. there is no `[artemistests_aeolus]` group in `hosts`, no host_var references it, and no playbook conditional depends on it. The variables defined in the file (`aeolus.url`, `aeolus.token`) were only consumed by the collection templates that are being removed in #208.

## Rollout order

Land [artemis-ansible-collection#208](https://github.com/ls1intum/artemis-ansible-collection/pull/208) first (or at least merge it before bumping the collection pin in this repo). Either order is safe in practice — the file is unreferenced today — but merging this one first makes the intent of the change-stack clearer.

## Test plan

- [ ] `ansible-lint` clean
- [ ] `ansible-inventory --list --yaml` parses without errors (no broken group reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)