### PR TITLE
Set up hermes deploy prod and hermes deploy staging

### DIFF
--- a/playbooks/hermes/hermes-deploy-prod.yml
+++ b/playbooks/hermes/hermes-deploy-prod.yml
@@ -1,5 +1,5 @@
 ---
-- name: Setup
+- name: Deploy Hermes Prod
   hosts: hermes-prod.artemis.cit.tum.de
 
   roles:

--- a/playbooks/hermes/hermes-deploy-prod.yml
+++ b/playbooks/hermes/hermes-deploy-prod.yml
@@ -1,0 +1,8 @@
+---
+- name: Setup
+  hosts: hermes-prod.artemis.cit.tum.de
+
+  roles:
+    - role: ls1intum.artemis.hermes
+      vars:
+        setup_system: false

--- a/playbooks/hermes/hermes-deploy-staging.yml
+++ b/playbooks/hermes/hermes-deploy-staging.yml
@@ -1,5 +1,5 @@
 ---
-- name: Setup
+- name: Deploy Hermes Staging
   hosts: hermes-staging.artemis.cit.tum.de
 
   roles:

--- a/playbooks/hermes/hermes-deploy-staging.yml
+++ b/playbooks/hermes/hermes-deploy-staging.yml
@@ -1,0 +1,8 @@
+---
+- name: Setup
+  hosts: hermes-staging.artemis.cit.tum.de
+
+  roles:
+    - role: ls1intum.artemis.hermes
+      vars:
+        setup_system: false


### PR DESCRIPTION
### Motivation and Context

We need dedicated Ansible playbooks to deploy Hermes to the production and staging hosts, mirroring the existing deployment setup for other services.

### Description

Adds two new playbooks under `playbooks/hermes/`:

- `hermes-deploy-prod.yml` — deploys Hermes to `hermes-prod.artemis.cit.tum.de`
- `hermes-deploy-staging.yml` — deploys Hermes to `hermes-staging.artemis.cit.tum.de`

Both playbooks apply the `ls1intum.artemis.hermes` role with `setup_system: false`.

`hermes_version` has to be set manually.

### Steps for Deployment

- Run `playbooks/hermes/hermes-deploy-staging.yml` to deploy Hermes to staging.
- Run `playbooks/hermes/hermes-deploy-prod.yml` to deploy Hermes to production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added automated deployment playbooks for Hermes in both production and staging environments, using the existing Hermes role while keeping system setup disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->