### PR TITLE
Remove Athena restricted_modules

### DIFF
--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -16,7 +16,6 @@ registry_external_host: registry.prod.artemis.cit.tum.de
 athena:
   url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('url') }}"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('secret') }}"
-  restricted_modules: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena').get('restricted_modules') }}"
 
 nebula:
   url: "https://prod.nebula.artemis.cit.tum.de"

--- a/group_vars/artemis_staging1.yml
+++ b/group_vars/artemis_staging1.yml
@@ -32,7 +32,6 @@ continuous_integration:
 athena:
   url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('url') }}"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('secret') }}"
-  restricted_modules: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('restricted_modules') }}"
 
 nebula:
   url: "https://test.nebula.artemis.cit.tum.de"

--- a/group_vars/artemis_staging2.yml
+++ b/group_vars/artemis_staging2.yml
@@ -32,7 +32,6 @@ continuous_integration:
 athena:
   url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('url') }}"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('secret') }}"
-  restricted_modules: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('restricted_modules') }}"
 
 nebula:
   url: "https://test.nebula.artemis.cit.tum.de"

--- a/group_vars/artemis_staging_localci.yml
+++ b/group_vars/artemis_staging_localci.yml
@@ -20,7 +20,6 @@ artemis_email: artemis-staging.aet@xcit.tum.de
 athena:
   url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('url') }}"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('secret') }}"
-  restricted_modules: "{{ lookup('hashi_vault', 'kv/data/artemis/common/athena-staging').get('restricted_modules') }}"
 
 nebula:
   url: "https://test.nebula.artemis.cit.tum.de"

--- a/group_vars/artemistest1.yml
+++ b/group_vars/artemistest1.yml
@@ -24,4 +24,3 @@ weaviate_collection_prefix: "Artemis_ts1_"
 athena:
   url: "https://athena-test1.aet.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest1').get('athena_secret') }}"
-  restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"

--- a/group_vars/artemistest2.yml
+++ b/group_vars/artemistest2.yml
@@ -12,7 +12,6 @@ weaviate_collection_prefix: "Artemis_ts2_"
 athena:
   url: "https://athena-test1.aet.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest2').get('athena_secret') }}"
-  restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"
 
 theia:
   portal_url: https://test2.theia-test.artemis.cit.tum.de/

--- a/group_vars/artemistest3.yml
+++ b/group_vars/artemistest3.yml
@@ -24,7 +24,6 @@ weaviate_collection_prefix: "Artemis_ts3_"
 athena:
   url: "https://athena-test1.aet.cit.tum.de"
   secret: "{{ lookup('hashi_vault', 'kv/data/artemis/test/artemistest3').get('athena_secret') }}"
-  restricted_modules: "module_text_llm,module_programming_llm,module_modeling_llm"
 
 atlas:
   atlasml:


### PR DESCRIPTION
## Summary
- Removes the `restricted_modules` field from the `athena` configuration block in all group_vars files (production, staging1, staging2, staging_localci, artemistest1-3)
- Aligns the ansible config with the upstream Artemis change that removed the restricted Athena module feature

## Test plan
- [ ] Verify Athena integration still works after deployment (url and secret remain intact)
- [ ] Confirm no Ansible lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated module restriction setting from several environment configurations.
  * Simplified Athena-related settings so only the connection details remain active.

* **Chores**
  * Cleaned up environment-specific configuration entries across production, staging, local CI, and test setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->