### PR TITLE
Add Let's Encrypt for certificates for prod proxy

### DIFF
--- a/group_vars/artemis_production.yml
+++ b/group_vars/artemis_production.yml
@@ -40,21 +40,16 @@ weaviate:
 
 proxy_generate_dh_param: false
 
-# Special TUM certificate config
-proxy_certificate_base_path: /opt/certs
-proxy_tum_certificate_key_name: artemis_tum_de-key.pem
-proxy_tum_certificate_name: artemis_tum_de.pem
-
 servers:
   - name: "artemis.tum.de"
-    ssl_certificate_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_name }}"
-    ssl_certificate_key_path: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_key_name }}"
+    ssl_certificate_path: /etc/letsencrypt/live/artemis.tum.de/fullchain.pem
+    ssl_certificate_key_path: /etc/letsencrypt/live/artemis.tum.de/privkey.pem
     default_server: true
 
 redirects:
-  - name: "artemis.ase.in.tum.de artemis.in.tum.de artemis.ase.cit.tum.de proxy.prod.artemis.cit.tum.de artemis.cs.tum.edu proxy-internal.prod.artemis.cit.tum.de prod.artemis.cit.tum.de asevm91.cit.tum.de artemis.cit.tum.de"
-    ssl_certificate_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.fullchain.pem
-    ssl_certificate_key_path: /var/lib/rbg-cert/live/host:f:asevm91.cit.tum.de.privkey.pem
+  - name: "artemis.ase.in.tum.de artemis.in.tum.de artemis.ase.cit.tum.de proxy.prod.artemis.cit.tum.de artemis.cs.tum.edu prod.artemis.cit.tum.de artemis.cit.tum.de"
+    ssl_certificate_path: /etc/letsencrypt/live/artemis.tum.de/fullchain.pem
+    ssl_certificate_key_path: /etc/letsencrypt/live/artemis.tum.de/privkey.pem
     default_server: false
     to: "{{ artemis_server_url }}"
 

--- a/playbooks/artemis-production/production-proxy.yml
+++ b/playbooks/artemis-production/production-proxy.yml
@@ -2,40 +2,30 @@
 - name: Setup Artemis Load Balancer / Reverse Proxy
   hosts: artemis_production_proxy
   pre_tasks:
-    - name: Create certificate dir on proxy
-      ansible.builtin.file:
-        dest: "{{ proxy_certificate_base_path }}"
-        state: directory
-        mode: "0700"
-        owner: "root"
-        group: "root"
-      become: true
-
-    - name: Copy certificates to proxy
-      ansible.builtin.copy:
-        src: "{{ item }}"
-        dest: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_name }}"
-        mode: "0755"
-        owner: "root"
-        group: "root"
-      with_fileglob:
-        - "artemis_tum_de-certificates/artemis_tum_de.pem"
-      become: true
-
-    - name: Get the tum certificate key from vault
-      ansible.builtin.set_fact:
-        artemis_tum_cert_key: "{{ lookup('hashi_vault', 'kv/data/artemis/production/proxy').get('artemis_tum_de-key') }}"
-
-    - name: Write tum certificate key to file
-      ansible.builtin.copy:
-        content: "{{ artemis_tum_cert_key }}"
-        dest: "{{ proxy_certificate_base_path }}/{{ proxy_tum_certificate_key_name }}"
-        mode: "0755"
-        owner: "root"
-        group: "root"
+    - name: Install certbot nginx plugin
+      ansible.builtin.package:
+        name: python3-certbot-nginx
+        state: present
+      tags: certbot
       become: true
 
   roles:
+    - role: geerlingguy.certbot
+      become: true
+      tags: certbot
+      vars:
+        certbot_auto_renew: true
+        certbot_auto_renew_hour: "3"
+        certbot_auto_renew_minute: "30"
+        certbot_auto_renew_user: root
+        certbot_auto_renew_options: "--quiet"
+        certbot_create_if_missing: true
+        certbot_admin_email: "{{ artemis_email }}"
+        certbot_certs:
+          - domains: "{{ (servers | map(attribute='name') | map('split', ' ') | flatten | list) + (redirects | map(attribute='name') | map('split', ' ') | flatten | list) }}"
+        certbot_create_standalone_stop_services:
+        certbot_create_command: "{{ certbot_script }} certonly --nginx --noninteractive --agree-tos --email {{ cert_item.email | default(certbot_admin_email) }} -d {{ cert_item.domains | join(',') }}"
+
     - role: ls1intum.artemis.firewall
       tags: firewall
       vars:

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,8 @@
 roles:
   - src: geerlingguy.docker
 
+  - src: geerlingguy.certbot
+
   - src: geerlingguy.mysql
     version: 6.2.0
 


### PR DESCRIPTION
### Motivation and Context
With shorter certificate lifetimes, we need an automated way to update our certificates for artemis.tum.de.
Due to political reasons at TUM, we cannot use certificates provided by the DFN/Geant. Instead, we have to use Let's Encrypt.

### Description
Install certbot and use the Let's Encrypt certificates for the nginx proxy.
We have to use a custom `certbot_create_command` because the `geerlingguy.certbot` role does not support the nginx plugin yet (see https://github.com/geerlingguy/ansible-role-certbot/issues/205).

