### PR TITLE
Remove LTI from prod-like

### DIFF
--- a/group_vars/artemis_prod_like_common.yml
+++ b/group_vars/artemis_prod_like_common.yml
@@ -28,9 +28,6 @@ artemis_internal_admin_password: "{{ lookup('hashi_vault', 'kv/data/artemis/' + 
 
 push_notification_relay: "https://hermes-prod.artemis.cit.tum.de"
 
-lti:
-  oauth_secret: "{{ lookup('hashi_vault', 'kv/data/artemis/' + var_vault_group).get('lti_secret') }}"
-
 ldap:
   url: "{{ lookup('hashi_vault', 'kv/data/artemis/common/ldap').get('ldap_url') }}"
   user_dn: "{{ lookup('hashi_vault', 'kv/data/artemis/common/ldap').get('ldap_dn') }}"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure that all continuous integration checks are passing. -->

### Motivation and Context
LTI is not really used. Having LTI enabled mainly means more maintenance burden for us, but no real advantage.


### Description
Remove LTI for prod-like setups.

