### PR TITLE
Enable passkey required for admin features for Artemis

### DIFF
--- a/group_vars/artemis_prod_like_core.yml
+++ b/group_vars/artemis_prod_like_core.yml
@@ -1,5 +1,6 @@
 ---
 artemis_passkey_enabled: true
+artemis_passkey_require_for_administrator_features: true
 
 continuous_integration:
   localci:


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure that all continuous integration checks are passing. -->

### Motivation and Context
Passkeys can enhance security because a password leak alone is not enough to use admin features. Therefore, we are enabling this feature.


### Description
Set the corresponding feature flag to true.

