### PR TITLE
Token-based apns Umstellung

### DIFF
--- a/playbooks/hermes/hermes.yml
+++ b/playbooks/hermes/hermes.yml
@@ -7,9 +7,10 @@
       vars:
         setup_system: true
         hermes_version: latest
-        hermes_apns_certificate_path: artemis-ios-apns-prod.p12
-        hermes_apns_certificate_password: "{{ lookup('hashi_vault', 'kv/data/artemis/{0}/hermes'.format(var_hermes_environment)).get('apns_certificate_password') }}"
-        hermes_apns_certificate_content: "{{ lookup('hashi_vault', 'kv/data/artemis/{0}/hermes'.format(var_hermes_environment)).get('apns_certificate_base64') }}"
+        hermes_apns_token_key_path: artemis-ios-apns-prod.p8
+        hermes_apns_team_id: "{{ lookup('hashi_vault', 'kv/data/artemis/{0}/hermes'.format(var_hermes_environment)).get('apns_team_id') }}"
+        hermes_apns_key_id: "{{ lookup('hashi_vault', 'kv/data/artemis/{0}/hermes'.format(var_hermes_environment)).get('apns_key_id') }}"
+        hermes_apns_token_key_content: "{{ lookup('hashi_vault', 'kv/data/artemis/{0}/hermes'.format(var_hermes_environment)).get('apns_token_key_base64') }}"
         hermes_google_application_credentials_json_path: artemis.json
         hermes_google_application_credentials_content: "{{ lookup('hashi_vault', 'kv/data/artemis/{0}/hermes'.format(var_hermes_environment)).get('google_certificate') }}"
         hermes_working_directory: /opt/hermes


### PR DESCRIPTION
### Motivation and Context

Hermes token-based JWT (a non-expiring `.p8` signing key + Team ID + Key ID). This changes the container's env-var contract, so the Hermes deployment config must supply the new variables from Vault.

Related PRs (coordinated deploy):
- ls1intum/Hermes#41 
- ls1intum/artemis-ansible-collection

### Description

`playbooks/hermes/hermes.yml` now passes token-based APNs config to the `hermes` role:

| Old (certificate) | New (token / JWT) |
|---|---|
| `hermes_apns_certificate_path` (`.p12`) | `hermes_apns_token_key_path` (`.p8`) |
| `hermes_apns_certificate_password` ← Vault `apns_certificate_password` | *removed* |
| — | `hermes_apns_team_id` ← Vault `apns_team_id` |
| — | `hermes_apns_key_id` ← Vault `apns_key_id` |
| `hermes_apns_certificate_content` ← Vault `apns_certificate_base64` | `hermes_apns_token_key_content` ← Vault `apns_token_key_base64` |

### Steps for Deployment

not deployed yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Apple Push Notification service authentication to use modern token-based credentials.
  * Improved notification delivery configuration by supporting the required Apple team and key identifiers.
  * Credentials continue to be securely sourced from the application’s secret management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->