### PR TITLE
Support direct Weaviate key rotation

### DIFF
--- a/group_vars/artemis_staging1.yml
+++ b/group_vars/artemis_staging1.yml
@@ -48,7 +48,7 @@ weaviate:
   open_ai_embedding_model: "Qwen/Qwen3-Embedding-8B"
   open_ai_base_url: https://logos.aet.cit.tum.de:8080/
   gpu_api_key: "{{ lookup('hashi_vault', 'kv/data/artemis/common/logos').get('staging_api_key') }}"
-  api_key: "{{ lookup('hashi_vault', 'kv/data/itg/services/services_ase/weaviate-test').get('api_key') }}"
+  api_key: "{{ lookup('hashi_vault', 'kv/data/itg/services/services_ase/weaviate-staging').get('api_key') }}"
 
 enable_science_event_logging: true
 

--- a/group_vars/artemis_staging2.yml
+++ b/group_vars/artemis_staging2.yml
@@ -48,7 +48,7 @@ weaviate:
   open_ai_embedding_model: "Qwen/Qwen3-Embedding-8B"
   open_ai_base_url: https://logos.aet.cit.tum.de:8080/
   gpu_api_key: "{{ lookup('hashi_vault', 'kv/data/artemis/common/logos').get('staging_api_key') }}"
-  api_key: "{{ lookup('hashi_vault', 'kv/data/itg/services/services_ase/weaviate-test').get('api_key') }}"
+  api_key: "{{ lookup('hashi_vault', 'kv/data/itg/services/services_ase/weaviate-staging').get('api_key') }}"
 
 enable_science_event_logging: true
 

--- a/hosts
+++ b/hosts
@@ -155,7 +155,7 @@ hermes-staging.artemis.cit.tum.de var_hermes_environment=test hermes_apns_prod_e
 [weaviate]
 weaviate-prod.artemis.cit.tum.de var_instance_name=weaviate
 weaviate-test.artemis.cit.tum.de var_instance_name=weaviate-test
-weaviate-staging.artemis.cit.tum.de var_instance_name=weaviate-test
+weaviate-staging.artemis.cit.tum.de var_instance_name=weaviate-staging
 
 ###############################
 # Artemis Staging 1

--- a/playbooks/weaviate/weaviate.yml
+++ b/playbooks/weaviate/weaviate.yml
@@ -16,7 +16,17 @@
         weaviate_domain: "{{ inventory_hostname }}"
         weaviate_build_version: "1.37.2"
         weaviate_api_user: weaviate_admin
-        weaviate_api_key: "{{ lookup('hashi_vault', 'kv/data/itg/services/services_ase/{0}'.format(var_instance_name)).get('api_key') }}"
+        weaviate_primary_api_key: >-
+          {{
+            lookup(
+              'hashi_vault',
+              'kv/data/itg/services/services_ase/{0}'.format(var_instance_name)
+            ).get('api_key')
+          }}
+        # Only the configured primary key is accepted.
+        weaviate_accepted_api_keys:
+          - "{{ weaviate_primary_api_key }}"
+        weaviate_apply_runtime: false
         letsencrypt_email: "ls1.itg@in.tum.de"
         weaviate_allowed_ips: "172.24.152.0/24,2a09:80c0:ac18:9800::/64,131.159.89.0/25,2a09:80c0:89::/64,131.159.89.128/25,2a09:80c0:89:1::/64,127.0.0.0/8,::1,192.168.0.0/16,172.24.70.0/25,2a09:80c0:ac18:4600::/64,172.24.70.128/25,2a09:80c0:ac18:4680::/64" # VPN, il01_7, il01_8, localhost, docker network, il01_2, il01_6
 


### PR DESCRIPTION
### Motivation and Context

Give the production, test, and staging Weaviate hosts independent replacement
credentials.

Related: ls1intum/artemis-ansible-collection#231

### Description

- Load the primary API key from the existing environment-specific Vault record.
- Configure that key as the only accepted Weaviate key.
- Add the dedicated `weaviate-staging` Vault mapping and use it for Artemis
  staging1/staging2.
- Keep runtime application explicit and disabled by default.

### Steps for Deployment

Weaviate prod, test, and staging are deployed. The Artemis staging1/staging2
consumer configuration remains for the Artemis owner.
