### PR TITLE
Exempt the benchmark server's IPv6 address too on staging1

### DIFF
--- a/group_vars/artemis_staging1.yml
+++ b/group_vars/artemis_staging1.yml
@@ -73,10 +73,14 @@ redirects:
 firewall_hostgroup: default
 proxy_forward_ssh: true
 
-# IPs exempt from git rate limiting (benchmark servers)
+# IPs exempt from the git and login rate limits (benchmark servers).
+# artemis-performance-test0.artemis.cit.tum.de is dual-stack, and the exemption matches whichever
+# address nginx sees, so both families have to be listed or an IPv6 run is silently throttled.
 proxy_rate_limit_exempt_ips:
   - ip: "131.159.89.112"
     comment: "Benchmark server"
+  - ip: "2a09:80c0:89::112"
+    comment: "Benchmark server (IPv6)"
 
 ##############################################################################
 # Broker and Registry Configuration


### PR DESCRIPTION
## Problem

`artemis-performance-test0.artemis.cit.tum.de` is dual-stack:

```
$ dig +short artemis-performance-test0.artemis.cit.tum.de A     -> 131.159.89.112
$ dig +short artemis-performance-test0.artemis.cit.tum.de AAAA  -> 2a09:80c0:89::112
```

Only the IPv4 address was in `proxy_rate_limit_exempt_ips`. nginx matches the exemption against the address it actually sees on the connection, so a benchmark run that resolves over IPv6 drops straight back into the rate-limited zones while the inventory still reads as though the host were exempt.

The symptom is not an error anyone would trace back to here. Throttled git traffic surfaces as clone and push latency, which reads as a storage or version-control problem in the benchmark report.

## Solution

List both address families. nginx's `geo` directive takes IPv6 literals, so no template change is needed for this part.

## Depends on

[artemis-ansible-collection#239](https://github.com/ls1intum/artemis-ansible-collection/pull/239), which extends the exemption from the git zones to the login zone. That one is the blocking half: without it, the benchmarking tool's login phase gets 429s from a single address and silently drops all but a handful of students, so a run above the smoke-test size cannot go through the proxy at all regardless of which address family it uses.

## Steps for testing

1. Merge the collection PR, then run `playbooks/artemis-staging1/proxy.yml`.
2. On the proxy host, confirm the rendered config lists both addresses in the `geo $rate_limit_exempt` block.
3. `nginx -t`, then reload.
4. Run a 100-student benchmark from `artemis-performance-test0` and confirm `grep -c ' 429 ' /var/log/nginx/access.log` stays flat over both address families.
