### PR TITLE
Size MySQL memory and I/O from the host instead of hardcoding it

### DIFF
--- a/group_vars/artemis_prod_like_mysql.yml
+++ b/group_vars/artemis_prod_like_mysql.yml
@@ -10,11 +10,42 @@ mysql_packages:
 mysql_bind_address: "{{ artemis_database_host }},localhost"
 
 # Performance
-mysql_key_buffer_size: "512M"
+# The key buffer caches MyISAM indexes only, and every table in every environment is InnoDB, so this
+# was 512 MB of memory reserved at startup and never read from. Kept at the documented minimum rather
+# than removed, because the server allocates a small key cache regardless.
+mysql_key_buffer_size: "32M"
 mysql_table_open_cache: "4000"
 mysql_sort_buffer_size: "4M"
 mysql_read_buffer_size: "1M"
-mysql_innodb_buffer_pool_size: "10G"
+# InnoDB reads and writes go straight to disk instead of through the operating system's page cache.
+# Without this, every hot data page is held twice: once in the buffer pool and once in the page cache.
+# That duplicate copy is what makes a large pool actively harmful rather than merely wasteful, because
+# the kernel can end up paging out anonymous pool memory to keep a file-backed copy of the same data.
+# Setting this is also what makes the share below safe to raise.
+mysql_innodb_flush_method: "O_DIRECT"
+
+# Every database host here is on SSD, but the flusher was budgeting for a single spinning disk, which is
+# what the 200 default assumes. Load testing found a host whose disk sat near fully busy at a third of
+# its CPU, which is a flusher falling behind rather than a disk running out.
+mysql_innodb_io_capacity: "2000"
+mysql_innodb_io_capacity_max: "4000"
+
+# Sized from the database host's own memory rather than hardcoded. One fixed value was shared by every
+# environment in this group, whose hosts differ in size by a factor of four, so a literal is wrong
+# somewhere by construction.
+#
+# A plain percentage is not enough either. What mysqld costs on top of its pool is close to a fixed
+# amount rather than a share, covering buffer pool control structures, per-connection buffers, thread
+# stacks, the log buffer, the doublewrite buffer and internal temporary tables. That is a small fraction
+# of a large host and a large fraction of a small one, so a single percentage either starves the big
+# host or drowns the small one.
+#
+# Hence a percentage with a floor. 70% suits a dedicated database host now that O_DIRECT means the page
+# cache is not holding a second copy of the same pages, and the reserve keeps the smaller hosts out of
+# swap where the percentage alone would not. The percentage governs the large hosts, the reserve
+# protects the small ones, and an environment that needs something different can override this in its
+# own group_vars.
+mysql_innodb_buffer_pool_size: "{{ [ (ansible_memtotal_mb * 0.7) | int, (ansible_memtotal_mb - 1800) | int ] | min }}M"
 mysql_max_connections: "2000"
 mysql_thread_cache_size: "256"
 mysql_max_allowed_packet: "4G"


### PR DESCRIPTION
## Problem

`group_vars/artemis_prod_like_mysql.yml` sets one value for every prod-like MySQL environment:

```yaml
mysql_innodb_buffer_pool_size: "10G"
```

Those database hosts differ in size by a factor of four, so a literal is wrong somewhere by construction. On the smaller hosts it asks for several times the memory available, and the result is `mysqld` being paged out. A buffer pool page that lives in swap costs a disk read to reach, which is the one thing the buffer pool exists to avoid, so an oversized pool is slower than a smaller one that fits.

This surfaced during load testing, where a database host showed near fully busy disk and noticeable iowait while its CPU stayed around a third.

## Change

Four settings, three of which belong together.

**`innodb_flush_method: O_DIRECT`.** Without it, InnoDB data goes through the OS page cache, so hot pages are held twice, once in the pool and once in the cache. That duplicate copy is what makes a large pool actively harmful rather than merely wasteful, since the kernel can page out anonymous pool memory in order to keep a file-backed copy of the same data. Removing it is also what makes the share below safe to raise.

**Pool sized from the host, with a floor:**

```yaml
mysql_innodb_buffer_pool_size: "{{ [ (ansible_memtotal_mb * 0.7) | int, (ansible_memtotal_mb - 1800) | int ] | min }}M"
```

A plain percentage is not enough on its own. What `mysqld` costs on top of its pool is close to a fixed amount rather than a share: buffer pool control structures, per-connection buffers, thread stacks, the log buffer, the doublewrite buffer and internal temporary tables. That is a small fraction of a large host and a large fraction of a small one, so one percentage either starves the big host or drowns the small one. The percentage governs the large hosts, the reserve protects the small ones, and an environment that needs something else can override it in its own `group_vars`.

**`innodb_io_capacity` 200 to 2000, and `innodb_io_capacity_max` 2000 to 4000.** Every database host here is on SSD and all were on the default that assumes a single spinning disk.

**`mysql_key_buffer_size` 512M to 32M.** The key buffer caches MyISAM indexes, and every table in every environment is InnoDB, so that half gigabyte was reserved at startup and never read from.

## Deliberately not included

`innodb_flush_log_at_trx_commit` is set to `2` on the staging1 host but is **not** part of this change. It removes an fsync per commit and is a sensible trade on a staging box, where losing up to a second of transactions in a host crash costs nothing. That trade is not one to make silently for every environment in this group, so it stays a per-host decision.

## Testing

Applied by hand on the staging1 database host and the running values confirmed through `performance_schema.global_variables`. A 1000-user benchmark was run against staging1 before and after:

| On the database host | before | after |
| --- | --- | --- |
| iowait | 7.0% | **0.1%** |
| disk utilisation | 95% | **23%** |
| CPU | 40% | 33% |

No errors in either run, application healthy throughout, and the smaller host is no longer paging `mysqld` out.

Worth being straight about the rest of the result: the client-observed benchmark numbers did not improve. This fixes real misconfiguration and removes a class of failure, but the database was not the binding constraint on that workload.

## Note

**Applying this restarts `mysqld`, so it needs a maintenance window.** The staging1 host already carries these values, so applying it there is effectively a no-op that still restarts the service.